### PR TITLE
Update Django Ninja installation instructions

### DIFF
--- a/docs/extensions/django.md
+++ b/docs/extensions/django.md
@@ -77,7 +77,7 @@ The `HelloService` will be automatically injected into the hello view through th
 Install `anydi` with `Django Ninja` support:
 
 ```sh
-pip install 'anydi-ninja'
+pip install 'anydi-django[ninja]'
 ```
 
 If you are using the [Django Ninja](https://django-ninja.dev/) framework, you can enable dependency injection by setting the `PATCH_NINJA` to `True`.


### PR DESCRIPTION
Changed the pip install command to use 'anydi-django[ninja]' instead of 'anydi-ninja' for Django Ninja support in the documentation.